### PR TITLE
Extend data_loading example and improve training writing

### DIFF
--- a/conda/pytorch-2.0.1-cuda-11.7.yaml
+++ b/conda/pytorch-2.0.1-cuda-11.7.yaml
@@ -22,3 +22,4 @@ dependencies:
     - zarr
     - opt_einsum
     - wandb
+    - jupyterlab

--- a/examples/data_loading.ipynb
+++ b/examples/data_loading.ipynb
@@ -29,13 +29,13 @@
     "### Create an h5py file\n",
     "In this case, we are using the simulation run with a wall temperature of 100 degrees Celsius.\n",
     "The simulation file includes a list of keys:\n",
-    "  1. dfun is the distance function from the bubbble interface\n",
-    "  2. pressure is the pressure gradient\n",
-    "  3. temperature is the temperature map\n",
-    "  4. velx is the velocity in the x direction\n",
-    "  5. vely is the velocity in the y direction\n",
-    "  6. x and y are coordinate grids\n",
-    "  7. int/real-runtime-params are metadata associated with the simulation run.\n",
+    "  1. `dfun` is a signed distance function from the bubbble interface\n",
+    "  2. `pressure` is the pressure gradient\n",
+    "  3. `temperature` is the temperature map\n",
+    "  4. `velx` is the velocity in the x direction\n",
+    "  5. `vely` is the velocity in the y direction\n",
+    "  6. `x` and `y `are coordinate grids\n",
+    "  7. `int/real-runtime-params` are metadata associated with the simulation run.\n",
     "     This includes things like the Reynold's number, simulation dimensions, etc."
    ]
   },
@@ -47,8 +47,8 @@
    "outputs": [],
    "source": [
     "twall_100 = h5py.File('Twall-100.hdf5', 'r')\n",
-    "\n",
-    "print(twall_100.keys())"
+    "for idx, key in enumerate(twall_100.keys()):\n",
+    "    print(f'{idx + 1}. {key}')"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "id": "dbf12cad",
    "metadata": {},
    "source": [
-    "### Visualizing the data\n",
+    "### Visualizing the different fields\n",
     "The data can be easily loaded into numpy (or torch, tensorflow, etc) arrays and visualized with matplotlib."
    ]
   },
@@ -118,12 +118,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e90f0013-12c9-4d90-8222-a0f9992eb8c3",
+   "metadata": {},
+   "source": [
+    "### Visualizing different timesteps\n",
+    "By progressively indexing along the time axis (dimension 0), we are able to see the progression as it leaves the heater surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fd72bae-590f-4a1e-aaf0-eae31f0e3a79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp = twall_100['temperature'][:]\n",
+    "mag = np.sqrt(twall_100['velx'][:]**2 + twall_100['vely'][:]**2)\n",
+    "\n",
+    "timesteps = range(40, 52, 2)\n",
+    "\n",
+    "fig, ax = plt.subplots(2, len(timesteps), figsize=(15, 5))\n",
+    "\n",
+    "for idx, step in enumerate(timesteps):\n",
+    "    ax[0, idx].imshow(np.flipud(temp[step]))\n",
+    "    ax[1, idx].imshow(np.flipud(mag[step]))\n",
+    "    for row in range(2):\n",
+    "        ax[row, idx].set_title(f'Step {step}')\n",
+    "        ax[row, idx].set_xticks([])\n",
+    "        ax[row, idx].set_yticks([])\n",
+    "    ax[0,0].set_ylabel('Temperature')\n",
+    "    ax[1,0].set_ylabel('Velocity Mag.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0fd957ba",
    "metadata": {},
    "source": [
     "### Using dfun\n",
     "dfun is a *signed distance function* to the liquid-vapor interfaces. \n",
-    "dfun > 0 means the point is in vapor, dfun < 0 means the point is in liquid. It is also a convenient way to identify the bubble interfaces."
+    "dfun > 0 means the point is in vapor, dfun < 0 means the point is in liquid. It is also a convenient way to identify the bubble interfaces. \n",
+    "\n",
+    "The function `get_interface_mask` matches the function used in the simulations. [See equation (8)](https://doi.org/10.1016/j.ijmultiphaseflow.2019.103099). We use numba to jit compile this function for performance."
    ]
   },
   {
@@ -158,8 +194,8 @@
    "source": [
     "fig, ax = plt.subplots(1, 5, figsize=(14, 5))\n",
     "\n",
-    "bubbles = dfun[50] >= 0\n",
-    "liquid = dfun[50] < 0\n",
+    "bubbles = dfun[50] >= 0  # vapor phase has non-negative distance.\n",
+    "liquid = dfun[50] < 0    # Liquid has negative distance.\n",
     "interface = get_interface_mask(dfun[50])\n",
     "\n",
     "data = {\n",
@@ -178,12 +214,67 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2fe398bb-8a38-4eec-972f-56df926012ba",
+   "metadata": {},
+   "source": [
+    "### Accessing the metadata\n",
+    "\n",
+    "There is a lot of metadata associated with each simulation. Pointers to some of the important metadata is listed in our [dataset documentation](https://github.com/HPCForge/BubbleML/blob/main/bubbleml_data/DOCS.md). The metadata is stored as a numpy array of tuples. Each tuple contains an array of bytes (the key) and a float (the value). The metadata stores critical information for the simulation. Some of these values (like the reynolds nunmber) will be necessary for training physics informed models."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1d656fa",
+   "id": "d5b86131-82ff-43ba-8ab3-47506f7f1db2",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "real_runtime_params = twall_100['real-runtime-params'][:]\n",
+    "key0, val0 = real_runtime_params[0]\n",
+    "\n",
+    "print(f'Metadata size: {real_runtime_params.shape}')\n",
+    "print(f'Key type: {type(key0)}')\n",
+    "print(f'Val type: {type(val0)}')\n",
+    "\n",
+    "def key_to_str(key):\n",
+    "    # convert byte string to a standard python utf-8 string.\n",
+    "    return key.decode('utf-8').strip()\n",
+    "\n",
+    "# Convert to a dict of (string, float64)\n",
+    "runtime_param_dict = dict([(key_to_str(key), val) for (key, val) in real_runtime_params])\n",
+    "\n",
+    "# print the reynolds number\n",
+    "inv_reynolds = runtime_param_dict['ins_invreynolds']\n",
+    "print(f'Reynolds Number: {1 / inv_reynolds}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27c9d2de-fbc4-4774-8d1a-efeba7df5fea",
+   "metadata": {},
+   "source": [
+    "### Getting the Domain Size\n",
+    "The simulations in BubbleML are not all the same size. So, it can be beneficial to know how to access the true spatial dimensions. \n",
+    "Here, we read the xy-extents from the metadata and set them as axis ticks on an image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7e74bdd-5d4f-44fc-9daa-0b917c6186ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmin, xmax = runtime_param_dict['xmin'], runtime_param_dict['xmax']\n",
+    "ymin, ymax = runtime_param_dict['ymin'], runtime_param_dict['ymax']\n",
+    "\n",
+    "print(f'x extents: {xmin}, {xmax}')\n",
+    "print(f'y extents: {ymin}, {ymax}')\n",
+    "\n",
+    "plt.imshow(np.flipud(temp[50]), extent=[xmin,xmax,ymin,ymax])\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {

--- a/examples/pytorch_training.ipynb
+++ b/examples/pytorch_training.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ae0243ab",
    "metadata": {},
    "outputs": [],
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "e117944a-9a00-48e1-bd3f-53d87611a5ba",
    "metadata": {},
    "outputs": [],
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "64445e91-35d4-44be-bc2d-ef268f6a0318",
    "metadata": {},
    "outputs": [],
@@ -70,6 +70,9 @@
     "        return self.timesteps - 1\n",
     "\n",
     "    def _get_input(self, idx):\n",
+    "        r\"\"\"\n",
+    "        The input is the temperature, x-velocity, and y-velocity at time == idx\n",
+    "        \"\"\"\n",
     "        temp = torch.from_numpy(self.data[TEMPERATURE][idx])\n",
     "        velx = torch.from_numpy(self.data[VELX][idx])\n",
     "        vely = torch.from_numpy(self.data[VELY][idx])\n",
@@ -77,9 +80,16 @@
     "        return torch.stack((temp, velx, vely), dim=0)\n",
     "\n",
     "    def _get_label(self, idx):\n",
+    "        r\"\"\"\n",
+    "        The output is the temperature at time == idx\n",
+    "        \"\"\"\n",
     "        return torch.from_numpy(self.data[TEMPERATURE][idx]).unsqueeze(0)\n",
     "    \n",
     "    def __getitem__(self, idx):\n",
+    "        r\"\"\"\n",
+    "        As input, get temperature and velocities at time == idx.\n",
+    "        As the output label, get the temperature at time == idx + 1.\n",
+    "        \"\"\"\n",
     "        input = self._get_input(idx)\n",
     "        label = self._get_label(idx+1)\n",
     "        return input, label"
@@ -96,10 +106,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "c466fa4c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train batches: 100\n",
+      "Val batches: 50\n"
+     ]
+    }
+   ],
    "source": [
     "train_files = ['Twall-100.hdf5', 'Twall-106.hdf5']\n",
     "val_files = ['Twall-103.hdf5']\n",
@@ -120,15 +139,23 @@
    "metadata": {},
    "source": [
     "### Creating a Model\n",
-    "We use `neuralop`s implementation of the Fourier Neural Operator (FNO). It has 3 input channels for `temperature`, `velx`, and `vely`. It outputs one channels for the temperature. We keep the lowest (16, 16) modes. As the dataset resolution has been reduced, we can't keep many more modes than this. As this is a simpler example, we use only 64 hidden channels and 4 layers."
+    "We use `neuralop`s implementation of the Fourier Neural Operator (FNO). It has 3 input channels because we input the `temperature`, `velx`, and `vely` for one timestep. It outputs one channels for the temperature at the following timestep. We keep the lowest (16, 16) modes. As the dataset resolution has been reduced, we can't keep many more modes than this. As this is a simpler example, we use only 64 hidden channels and 4 layers."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "edb3ddcf-fdf7-45b0-9276-2a7e39eaf65e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FNO uses 4228097 parameters\n"
+     ]
+    }
+   ],
    "source": [
     "def count_parameters(model):\n",
     "    return sum(p.numel() for p in model.parameters() if p.requires_grad)\n",

--- a/video/README.md
+++ b/video/README.md
@@ -18,6 +18,13 @@ trails are formed.
 
 ![](saturated.gif)
 
+## Pool Boiling Subcooled, Velocity Field
+
+This shows the velocity field for subcooled boiling. This is the result
+of the UNet-mod, trained using the push-forward trick.
+
+![](vel.gif)
+
 ## Flow Boiling Inlet Velocity
 
 This illustrates how changing the inlet velocity affects


### PR DESCRIPTION
This extends the data_loading example to show visualizations of progressive timesteps, how to read the metadata to get info like the Reynold's number, get domain extents, and also makes some writing improvments.
It also adds a gif of the P-UNet-mod velocity predictions